### PR TITLE
(createDispatchedActions) add actionType to dispatchedAction

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -101,6 +101,7 @@ export function createDispatchedActions<Ducks>(ducks: Ducks, store: Store): Duck
             if (duck instanceof Function) {
                 const dispatchedActionHandler = createDispatchedActionHandler(duck);
                 dispatchedActions[name] = dispatchedActionHandler;
+                dispatchedActions[name].actionType = duck.actionType;
             } else if (duck instanceof Object) {
                 dispatchedActions[name] = createDispatchedActions(duck, store);
             }

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -157,6 +157,12 @@ describe('Given some nested ducks.', () => {
             expect(dispatchedActions[0].payload).toBe('payload');
         });
 
+        it('provides the actionType for each duck', () => {
+            const diveAction = actions.nested.dive;
+
+            expect(diveAction.actionType).toBe('DIVE');
+        })
+
         it('provides each duck action with returning actual action object', () => {
             const action = actions.nested.dive();
 


### PR DESCRIPTION
## Purpose

This allows to read the type of an action.
In this way a duck can be used inside an epic or effect.
The action type can be used to create a customized action which can be dispatched by the effect middleware.

This PR is related to #3 (Provide async ducks).
In order to use this library along with @ngrx/platform ore @angular-redux/store I prepared this pull request.

## Usage in ngrx

```typescript
export class MyEffects {
 constructor(asyncronuous: Service, actions: DispatchedActions) {}  

  @Effect()
  loadAll = this.actions$.ofType(actions.board.loadAll.actionType).exhaustMap(action => {
    this.asyncronuous
      .operation()
      .map(result => (
          type: actions.board.loadAllSuccess.actionType,
          payload: result
       ))
  });
}
```

## Thoughts regarding silent ducks

Using epics means that there are actions having no payload reducer.
I wonder if making the payload reducer optional.
That's why I call it silent duck.
It just allows us to declare the action type.
The silent duck itself is handled by an effect.
