### PR TITLE
Improved type definitions and made payload non-nullable

### DIFF
--- a/lib/createDuck.ts
+++ b/lib/createDuck.ts
@@ -13,6 +13,11 @@ export interface Duck<TState, TPayload = any> {
     (payload?: TPayload): Action<TPayload>;
     actionType: string;
     payloadReducer: PayloadReducer<TState, TPayload>;
+    /**
+     * This variable is never used.
+     * It is provided to allow for example "type MyAction = typeof myDuck.ActionTypeDef;"
+     */
+    ActionTypeDef: Action<TPayload>;
 }
 
 export interface DuckWithoutPayload<TState> extends Duck<TState> {

--- a/lib/createDuck.ts
+++ b/lib/createDuck.ts
@@ -1,36 +1,40 @@
-export type Action<TPayload> = {
+export interface BaseAction {
     type: string;
-    payload?: TPayload;
-};
+}
 
-export type PayloadReducer<TState, TPayload> = {
-    (state: TState, payload: TPayload): TState;
-};
+export interface Action<TPayload> extends BaseAction {
+    type: string;
+    payload: TPayload;
+}
 
-export type Duck<TState, TPayload> = {
+export type PayloadReducer<TState, TPayload> = (state: TState, payload: TPayload) => TState;
+
+export interface Duck<TState, TPayload = any> {
     (payload?: TPayload): Action<TPayload>;
     actionType: string;
     payloadReducer: PayloadReducer<TState, TPayload>;
-};
+}
 
-export type DuckTree<TState> = {
-    [key: string]: Duck<TState, any> | DuckTree<TState>;
-};
+export interface DuckWithoutPayload<TState> extends Duck<TState> {
+    (): BaseAction;
+    actionType: string;
+    payloadReducer: PayloadReducer<TState, void>;
+}
+
+export interface DuckTree<TState> {
+    [key: string]: Duck<TState> | DuckTree<TState>;
+}
 
 /**
  * Creates a new duck which is an action creator in a first place.
  * Use createActionDispatchers() to convert an object literal with ducks
  * into a set of self-dispatching actions.
  */
-export function createDuck<TState, TPayload>(type: string, payloadReducer: PayloadReducer<TState, TPayload>): Duck<TState, TPayload> {
-    const duck = <any> ((payload: TPayload) => {
-        return {
-            type,
-            payload
-        };
-    });
+export function createDuck<TState>(type: string, payloadReducer: PayloadReducer<TState, void>): DuckWithoutPayload<TState>;
+export function createDuck<TState, TPayload>(type: string, payloadReducer: PayloadReducer<TState, TPayload>): Duck<TState, TPayload>;
+export function createDuck(type, payloadReducer) {
+    const duck: any = (payload: any) => ({ type, payload });
     duck.actionType = type;
     duck.payloadReducer = payloadReducer;
-
     return duck;
 }

--- a/lib/createReducer.ts
+++ b/lib/createReducer.ts
@@ -1,7 +1,7 @@
-import { Action, Duck, DuckTree } from './createDuck';
+import { BaseAction, Action, Duck, DuckTree } from './createDuck';
 
 export type Reducer<TState> = {
-    (state: TState, action: Action<any>): TState;
+    (state: TState, action: BaseAction | Action<any>): TState;
 };
 
 /**
@@ -29,9 +29,9 @@ function flatMapFunctions(obj) {
 /**
  * Creates a reducer function from given tree of ducks (object literal).
  */
-export function createReducer<TState>(duckTree: DuckTree<TState> | Duck<TState, any>, initialState = <TState>{}): Reducer<TState> {
+export function createReducer<TState>(duckTree: DuckTree<TState> | Duck<TState>, initialState = <TState>{}): Reducer<TState> {
     if (duckTree instanceof Function) {
-        const duck = <Duck<TState, any>> duckTree;
+        const duck = duckTree as Duck<TState>;
         const actionType = duck.actionType;
         const payloadReducer = duck.payloadReducer;
 
@@ -46,7 +46,7 @@ export function createReducer<TState>(duckTree: DuckTree<TState> | Duck<TState, 
 
     // slice the ducks and prepare payload reducers lookup object
     const payloadReducers = Object.keys(flatDucks).reduce((payloadReducers, k) => {
-        const duck = <Duck<TState, any>> flatDucks[k];
+        const duck = flatDucks[k] as Duck<TState>;
         const actionType = duck.actionType;
         const payloadReducer = duck.payloadReducer;
 

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -1,4 +1,4 @@
-import {Duck, createDuck, createReducer, createActionDispatchers, createScopedReducers} from '../index';
+import { Action, Duck, createDuck, createReducer, createActionDispatchers, createScopedReducers } from '../index';
 
 const replaceReducer = (state: string, payload: string) => {
     return payload;
@@ -280,7 +280,7 @@ describe('Given some nested ducks.', () => {
             const action = actions.nested.dive();
 
             expect(action.type).toBe('DIVE');
-            expect(action.payload).toBeUndefined();
+            expect((action as Action<any>).payload).toBeUndefined();
         });
     });
 });


### PR DESCRIPTION
This PR splits `Action<T>` into `BaseAction` which does not have a payload and `Action<T>` which has a payload which is **non-nullable**.

This PR also adjusts the type definition for createDuck to return Ducks either with or without a payload to match above changes.

It also adds a utility declaration of `ActionTypeDef` to Ducks to allow using typeof on Ducks to get the type of Action they create.

An example where this change becomes important using e.g. `redux-observable`:
```typescript
export const getProduct = createDuck<ProductStore, string>('product/GET', (s, p) => {
    return {
        ...s,
        state: { ...s.state, [p]: 'loading' },
    };
});

export const getProductEpic: Epic<typeof getProduct.ActionTypeDef, ProductStore, any, Action> = (action$) => action$.pipe(
    ofType(getProduct.actionType),
    delay(1000),
    map(x => loadedProduct({
        id: x.payload, // this will throw a compile error because payload can be undefined
        name: `Product ${x.payload}`,
        amount: 0,
    }))
);
```