### PR TITLE
ts-compiler option no-implicit-any

### DIFF
--- a/lib/createActionDispatchers.ts
+++ b/lib/createActionDispatchers.ts
@@ -1,7 +1,7 @@
 import { Action } from './createDuck';
 
 export type Store = {
-    dispatch(action: Action<any>) : any;
+    dispatch(action: Action<any>): any;
 };
 
  /**

--- a/lib/createActionDispatchers.ts
+++ b/lib/createActionDispatchers.ts
@@ -1,7 +1,7 @@
 import { Action } from './createDuck';
 
 export type Store = {
-    dispatch(action: Action<any>);
+    dispatch(action: Action<any>) : any;
 };
 
  /**


### PR DESCRIPTION
Gives the store a explict return type of any in order to pass the no-implicit-any ts compiler flag in consuming applications. 

This prevents errors like : ERROR in node_modules/redux-typed-ducks/dist/index.d.ts(32,5): error TS7010: 'dispatch', which lacks return-type annotation, implicitly has an 'any' return type.

would have preferd to use void like the redux store type but that conflicts with the createDispatchedActionHandler function.